### PR TITLE
Changed for correct compilation on Linux with gcc 4.8 and awpmd-dft

### DIFF
--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -166,13 +166,13 @@ QT_AUTOBRIEF           = NO
 MULTILINE_CPP_IS_BRIEF = NO
 
 # If the INHERIT_DOCS tag is set to YES (the default) then an undocumented 
-# member inherits the documentation from any documented member that it 
+# member inherits the documentation from any documented var_field that it
 # re-implements.
 
 INHERIT_DOCS           = YES
 
 # If the SEPARATE_MEMBER_PAGES tag is set to YES, then doxygen will produce 
-# a new page for each member. If set to NO, the documentation of a member will 
+# a new page for each member. If set to NO, the documentation of a var_field will
 # be part of the file/class/namespace that contains it.
 
 SEPARATE_MEMBER_PAGES  = NO

--- a/include/pencil.h
+++ b/include/pencil.h
@@ -88,6 +88,7 @@ $Date: 2009/07/24 05:08:46 $
 #define PENCIL_H
 
 # include <algorithm> 
+#include <cstring>
 
 using namespace std;
 

--- a/include/statist.h
+++ b/include/statist.h
@@ -521,7 +521,7 @@ public:
      dx = (x2 - x1) / (3 * (n - 1));
    for (x = x1; x<xlim; x += dx)
      mult += distr(x)*x*x*dx;
-   return isnan(1./mult) ?  1. : mult ;
+   return std::isnan(1./mult) ?  1. : mult ;
  }
 
 

--- a/include/vector_3.h
+++ b/include/vector_3.h
@@ -163,6 +163,7 @@ struct array_stor_t{
 ///\ru N-мерный вектор типа T с некоторыми полезными операциями
 template <class T, size_t N, class storage_t= array_stor_t<T,N> > 
 class Vector_Nt{
+public:
   storage_t v;
   
 public:  


### PR DESCRIPTION
Изменены права доступа к полю "storage_t v" в классе "Vector_Nt", что позволяет преобразовывать WavePacket из wavepacket.h в GaussPacket из awpmd-dft/DataTypes.hpp